### PR TITLE
Pixiewps 1.1 enforces mutual exclusivity with -r and -S options.

### DIFF
--- a/src/wps/wps_registrar.c
+++ b/src/wps/wps_registrar.c
@@ -1838,8 +1838,12 @@ static int wps_process_e_hash2(struct wps_data *wps, const u8 *e_hash2)
     
     strcat(cmd_pixie,"pixiewps -e ");
     strcat(cmd_pixie,pixie_pke);
-    strcat(cmd_pixie," -r ");
-    strcat(cmd_pixie,pixie_pkr);
+
+    if(globule->dh_small != 1){
+        strcat(cmd_pixie," -r ");
+        strcat(cmd_pixie,pixie_pkr);
+    }
+
     strcat(cmd_pixie," -s ");
     strcat(cmd_pixie,pixie_ehash1);
     strcat(cmd_pixie," -z ");


### PR DESCRIPTION
The latest version of Pixiewps in the Kali repository is 1.1. With this version, -r and -S are mutually exclusive and specifying both results in the help message, causing reaver to fail. This commit resolves that problem.