### PR TITLE
mon0 -> wlan0mon

### DIFF
--- a/docs/README.REAVER
+++ b/docs/README.REAVER
@@ -2,54 +2,54 @@ REAVER USAGE
 
         Usually, the only required arguments to Reaver are the interface name and the BSSID of the target AP:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05
+                # reaver -i wlan0mon -b 00:01:02:03:04:05
 
 	It is suggested that you run Reaver in verbose mode in order to get more detailed information about
 	the attack as it progresses:
 
-		# reaver -i mon0 -b 00:01:02:03:04:05 -vv
+		# reaver -i wlan0mon -b 00:01:02:03:04:05 -vv
 
         The channel and SSID (provided that the SSID is not cloaked) of the target AP will be automatically
         identified by Reaver, unless explicitly specified on the command line:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 -c 11 -e linksys
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 -c 11 -e linksys
 
         Since version 1.3, Reaver implements the small DH key optimization as suggested by Stefan which can
         speed up the attack speed:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --dh-small
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --dh-small
 
         By default, if the AP switches channels, Reaver will also change its channel accordingly. However,
         this feature may be disabled by fixing the interface's channel:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --fixed
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --fixed
 
 	When spoofing your MAC address, you must set the desired address to spoof using the ifconfig utility,
 	and additionally tell Reaver what the spoofed address is:
 
-		# reaver -i mon0 -b 00:01:02:03:04:05 --mac=AA:BB:CC:DD:EE:FF
+		# reaver -i wlan0mon -b 00:01:02:03:04:05 --mac=AA:BB:CC:DD:EE:FF
 
 	The default receive timeout period is 5 seconds. This timeout period can be set manually if necessary
         (minimum timeout period is 1 second):
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 -t 2
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 -t 2
 
         The default delay period between pin attempts is 1 second. This value can be increased or decreased
         to any non-negative integer value. A value of zero means no delay:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 -d 0
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 -d 0
 
         Some APs will temporarily lock their WPS state, typically for five minutes or less, when "suspicious"
         activity is detected. By default when a locked state is detected, Reaver will check the state every
         315 seconds (5 minutes and 15 seconds) and not continue brute forcing pins until the WPS state is unlocked.
         This check can be increased or decreased to any non-negative integer value:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --lock-delay=250
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --lock-delay=250
 
         The default timeout period for receiving the M5 and M7 WPS response messages is .1 seconds. This
         timeout period can be set manually if necessary (max timeout period is 1 second):
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 -T .5
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 -T .5
 
         Some poor WPS implementations will drop a connection on the floor when an invalid pin is supplied
         instead of responding with a NACK message as the specs dictate. To account for this, if an M5/M7 timeout
@@ -57,15 +57,15 @@ REAVER USAGE
         NACKS (most do), this feature can be disabled to ensure better reliability. This option is largely useless
         as Reaver will auto-detect if an AP properly responds with NACKs or not:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --nack
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --nack
 
         While most APs don't care, sending an EAP FAIL message to close out a WPS session is sometimes necessary.
         By default this feature is disabled, but can be enabled for those APs that need it:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --eap-terminate
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --eap-terminate
 
         When 10 consecutive unexpected WPS errors are encountered, a warning message will be displayed. Since this
         may be a sign that the AP is rate limiting pin attempts or simply being overloaded, a sleep can be put in
         place that will occur whenever these warning messages appear:
 
-                # reaver -i mon0 -b 00:01:02:03:04:05 --fail-wait=360
+                # reaver -i wlan0mon -b 00:01:02:03:04:05 --fail-wait=360

--- a/docs/README.WASH
+++ b/docs/README.WASH
@@ -2,7 +2,7 @@ WASH USAGE
 
 	Wash is a utility for identifying WPS enabled access points. It can survey from a live interface:
 
-		# wash -i mon0 
+		# wash -i wlan0mon
 
 	Or it can scan a list of pcap files:
 
@@ -20,7 +20,7 @@ WASH USAGE
 	By default, wash will perform a passive survey. However, wash can be instructed to send probe requests
 	to each AP in order to obtain more information about the AP:
 
-		# wash -i mon0 --scan
+		# wash -i wlan0mon --scan
 
 	By sending probe requests, wash will illicit a probe response from each AP. For WPS-capable APs, the
 	WPS information element typically contains additional information about the AP, including make, model,

--- a/src/wpscrack.c
+++ b/src/wpscrack.c
@@ -88,8 +88,8 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Sanity checking on the message timeout value */	
-    if(get_m57_timeout() > M57_MAX_TIMEOUT) 
+    /* Sanity checking on the message timeout value */
+    if(get_m57_timeout() > M57_MAX_TIMEOUT)
     {
         set_m57_timeout(M57_MAX_TIMEOUT);
     }
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
         ret_val = EXIT_SUCCESS;
     }
-    else 
+    else
     {
         cprintf(CRITICAL, "[-] Failed to recover WPA key\n");
     }
@@ -171,7 +171,7 @@ int usage(char *prog_name)
     fprintf(stderr, "\t-v, --verbose                   Display non-critical warnings (-vv for more)\n");
     fprintf(stderr, "\t-q, --quiet                     Only display critical messages\n");
     //fprintf(stderr, "\t-K, --pixie-dust                Test Pixie Dust [1] Basic(-S) [2] With E-Once(-S) [3] With PKR \n");
-    fprintf(stderr, "\t-K  --pixie-dust=<number>       [1] Run pixiewps with PKE, PKR, E-Hash1, E-Hash2 and E-Nonce (Ralink, Broadcom, Realtek)\n");
+    fprintf(stderr, "\t-K  --pixie-dust=<number>       [1] Run pixiewps with PKE, PKR, E-Hash1, E-Hash2 and E-Nonce (Ralink, Broadcom & Realtek)\n");
     fprintf(stderr, "\t-Z, --no-auto-pass              Do NOT run reaver to auto retrieve WPA password if Pixiewps attack is successful\n");
     fprintf(stderr, "\t-h, --help                      Show help\n");
 
@@ -198,8 +198,8 @@ int usage(char *prog_name)
     fprintf(stderr, "\t-W, --generate-pin              Default Pin Generator [1] Belkin [2] D-Link [3] Zyxel\n");
     fprintf(stderr, "\t-H, --pixiedust-log             Enables logging of sequence completed PixieHashes\n");
 
-	
-    fprintf(stderr, "\nExample:\n\t%s -i mon0 -b 00:90:4C:C1:AC:21 -vv -K 1\n\n", prog_name);
+
+    fprintf(stderr, "\nExample:\n\t%s -i wlan0mon -b 00:90:4C:C1:AC:21 -vvv -K 1\n\n", prog_name);
 
     return EXIT_FAILURE;
 }

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
         { "help", no_argument, NULL, 'h' },
         { 0, 0, 0, 0 }
     };
-	
+
 
     globule_init();
     sql_init();
@@ -137,13 +137,13 @@ int main(int argc, char *argv[])
             last_optarg = strdup(optarg);
         }
     }
-	
+
 	if (o_file_p == 0)
 	{
 		printf("\nWash v%s WiFi Protected Setup Scan Tool\n", PACKAGE_VERSION);
 		printf("Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>\n");
 		printf("mod by t6_x <t6_x@hotmail.com> & DataHead & Soxrok2212 & Wiire & kib0rg\n\n");
-	}	
+	}
 
     /* The interface value won't be set if capture files were specified; else, there should have been an interface specified */
     if(!get_iface() && source != PCAP_FILE)
@@ -173,19 +173,19 @@ int main(int argc, char *argv[])
     /* Open the output file, if any. If none, write to stdout. */
     if(out_file)
     {
-	
+
 		fp = fopen(out_file, "wb");
 		if(!fp)
 		{
 			cprintf(CRITICAL, "[X] ERROR: Failed to open '%s' for writing\n", out_file);
 			goto end;
 		}
-		
+
 
         set_log_file(fp);
     }
 
-    /* 
+    /*
      * Loop through all of the specified capture sources. If an interface was specified, this will only loop once and the
      * call to monitor() will block indefinitely. If capture files were specified, this will loop through each file specified
      * on the command line and monitor() will return after each file has been processed.
@@ -263,9 +263,9 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
     /* If we aren't reading from a pcap file, set the interface channel */
     if(source == INTERFACE)
     {
-        /* 
-         * If a channel has been specified, set the interface to that channel. 
-         * Else, set a recurring 1 second timer that will call sigalrm() and switch to 
+        /*
+         * If a channel has been specified, set the interface to that channel.
+         * Else, set a recurring 1 second timer that will call sigalrm() and switch to
          * a new channel.
          */
         if(channel > 0)
@@ -289,7 +289,7 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 			cprintf(INFO, "--------------------------------------------------------------------------------------\n");
 			header_printed = 1;
 		}
-		
+
     }
 
     while((packet = next_packet(&header)))
@@ -310,7 +310,7 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
     char *bssid = NULL, *ssid = NULL, *lock_display = NULL;
     int wps_parsed = 0, probe_sent = 0, channel = 0, rssi = 0;
     static int channel_changed = 0;
-    
+
     char info_manufac[500];
     char info_modelnum[500];
     char info_modelserial[500];
@@ -324,7 +324,7 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
     }
 
     rt_header = (struct radio_tap_header *) radio_header(packet, header->len);
-    
+
     frame_header = (struct dot11_frame_header *) (packet + rt_header->len);
 
     /* If a specific BSSID was specified, only parse packets from that BSSID */
@@ -352,10 +352,10 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
                 change_channel(channel);
                 channel_changed = 1;
             }
-            
-            
-            
-            
+
+
+
+
 
             if(frame_header->fc.sub_type == PROBE_RESPONSE ||
                     frame_header->fc.sub_type == SUBTYPE_BEACON)
@@ -366,8 +366,8 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
             if(!is_done(bssid) && (get_channel() == channel || source == PCAP_FILE))
             {
                 if(frame_header->fc.sub_type == SUBTYPE_BEACON &&
-                        mode == SCAN && 
-                        !passive && 
+                        mode == SCAN &&
+                        !passive &&
                         should_probe(bssid))
                 {
                     send_probe_request(get_bssid(), get_ssid());
@@ -390,9 +390,9 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
                             lock_display = NO;
                             break;
                     }
-					
+
 					//ideas made by kcdtv
-					
+
 					if(get_chipset_output == 1)
 					//if(1)
 					{
@@ -402,44 +402,44 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 							cprintf(INFO,"Option (-g) REQUIRES a channel to be set with (-c)\n");
 							exit(0);
 						}
-						
+
 						FILE *fgchipset=NULL;
 						char cmd_chipset[4000];
 						char cmd_chipset_buf[4000];
 						char buffint[5];
-						
-						char *aux_cmd_chipset=NULL;
-						
 
-						
+						char *aux_cmd_chipset=NULL;
+
+
+
 						memset(cmd_chipset, 0, sizeof(cmd_chipset));
 						memset(cmd_chipset_buf, 0, sizeof(cmd_chipset_buf));
 						memset(info_manufac, 0, sizeof(info_manufac));
                         memset(info_modelnum, 0, sizeof(info_modelnum));
                         memset(info_modelserial, 0, sizeof(info_modelserial));
-						
 
-						
+
+
 						strcat(cmd_chipset,"reaver -0 -s y -vv -i "); //need option to stop reaver in m1 stage
 						strcat(cmd_chipset,get_iface());
-						
+
 						strcat(cmd_chipset, " -b ");
 						strcat(cmd_chipset, mac2str(get_bssid(),':'));
-						
+
 						strcat(cmd_chipset," -c ");
 						snprintf(buffint, sizeof(buffint), "%d",channel);
 						strcat(cmd_chipset, buffint);
-						
+
 						//cprintf(INFO,"\n%s\n",cmd_chipset);
 
 						if ((fgchipset = popen(cmd_chipset, "r")) == NULL) {
 							printf("Error opening pipe!\n");
 							//return -1;
 						}
-						
-						
 
-						while (fgets(cmd_chipset_buf, 4000, fgchipset) != NULL) 
+
+
+						while (fgets(cmd_chipset_buf, 4000, fgchipset) != NULL)
 						{
 							//[P] WPS Manufacturer: xxx
 							//[P] WPS Model Number: yyy
@@ -450,7 +450,7 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 							if(aux_cmd_chipset != NULL)
 							{
 								//bug fix by alxchk
-								strncpy(info_manufac, aux_cmd_chipset+21, sizeof(info_manufac));							
+								strncpy(info_manufac, aux_cmd_chipset+21, sizeof(info_manufac));
 							}
 
 							aux_cmd_chipset = strstr(cmd_chipset_buf,"[P] WPS Model Number:");
@@ -458,7 +458,7 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 							{
                                 //bug fix by alxchk
 								strncpy(info_modelnum, aux_cmd_chipset+21, sizeof(info_modelnum));
-								
+
 							}
 
 							aux_cmd_chipset = strstr(cmd_chipset_buf,"[P] WPS Model Serial Number:");
@@ -466,16 +466,16 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 							{
                                 //bug fix by alxchk
 								strncpy(info_modelserial, aux_cmd_chipset+28, sizeof(info_modelserial));
-								
+
 							}
 
 						}
-						
+
 						//cprintf(INFO,"\n%s\n",info_manufac);
 						info_manufac[strcspn ( info_manufac, "\n" )] = '\0';
 						info_modelnum[strcspn ( info_modelnum, "\n" )] = '\0';
 						info_modelserial[strcspn ( info_modelserial, "\n" )] = '\0';
-						
+
 
 
                         if(pclose(fgchipset))  {
@@ -483,11 +483,11 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
                         //return -1;
                         }
 
-					
+
 
 					}
-					
-					
+
+
 					if (o_file_p == 0)
 					{
 						cprintf(INFO, "%17s    %2d       %.2d   %d.%d          %s         %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, ssid);
@@ -497,13 +497,13 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 						if(get_chipset_output == 1)
 						{
 							cprintf(INFO, "%17s|%2d|%.2d|%d.%d|%s|%s|%s|%s|%s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, ssid, info_manufac, info_modelnum, info_modelserial);
-							
+
 						}else
 						{
 							cprintf(INFO, "%17s|%2d|%.2d|%d.%d|%s|%s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, ssid);
-							
+
 						}
-						
+
 					}
                 }
 
@@ -583,7 +583,7 @@ void usage(char *prog)
     fprintf(stderr, "\t-h, --help                           Show help\n");
 
     fprintf(stderr, "\nExample:\n");
-    fprintf(stderr, "\t%s -i mon0\n\n", prog);
+    fprintf(stderr, "\t%s -i wlan0mon\n\n", prog);
 
     return;
 }


### PR DESCRIPTION
Since the release of **Aircrack-ng v1.2 RC2**, it now uses what was `aircrack-zc` as default for `airmon-ng`. As a result, the interface name has changed for monitor mode from `mon0` to `wlan0mon`.

All places **expect** `README.md` as its been done in #18.