### PR TITLE
crypto: build with -fno-strict-aliasing

### DIFF
--- a/src/crypto/Makefile
+++ b/src/crypto/Makefile
@@ -11,6 +11,7 @@ include ../common/lib.rules
 
 CFLAGS += -DCONFIG_TLS_INTERNAL_CLIENT
 CFLAGS += -DCONFIG_TLS_INTERNAL_SERVER
+CFLAGS += -fno-strict-aliasing
 #CFLAGS += -DALL_DH_GROUPS
 
 LIB_OBJS= \


### PR DESCRIPTION
this warning here

md5-internal.c:186:5: warning:
dereferencing type-punned pointer will break strict-aliasing rules
[-Wstrict-aliasing]

is serious UB and as such may lead to all kinds of evil compiler behaviour.
fix it by sacrificing a little bit of performance and disabling the
strict aliasing optimization.