### PR TITLE
Fixed error: pcap library not found! in configure.ac file for FreeBSD

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -577,8 +577,8 @@ MAKEFLAGS=
 # Identity of this package.
 PACKAGE_NAME='reaver'
 PACKAGE_TARNAME='reaver'
-PACKAGE_VERSION='1.5.3'
-PACKAGE_STRING='reaver 1.5.3'
+PACKAGE_VERSION='1.5'
+PACKAGE_STRING='reaver 1.5'
 PACKAGE_BUGREPORT=''
 PACKAGE_URL=''
 
@@ -2806,8 +2806,18 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+
 CFLAGS="-Wall $CFLAGS"
-LDFLAGS="-ldl -lm -lpcap -lsqlite3 $LDFLAGS"
+
+
+if test `uname` = "FreeBSD"; then
+  LDFLAGS="-lpcap -lsqlite3 $LDFLAGS"
+else
+  LDFLAGS="-ldl -lm -lpcap -lsqlite3 $LDFLAGS"
+fi
+
+
+
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pcap_open_live in -lpcap" >&5

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3,8 +3,18 @@ AC_INIT(reaver, 1.5)
 AC_PROG_CC
 AC_LANG(C)
 
+
 CFLAGS="-Wall $CFLAGS"
-LDFLAGS="-ldl -lm -lpcap -lsqlite3 $LDFLAGS"
+
+
+if test `uname` = "FreeBSD"; then
+  LDFLAGS="-lpcap -lsqlite3 $LDFLAGS"
+else
+  LDFLAGS="-ldl -lm -lpcap -lsqlite3 $LDFLAGS"
+fi
+
+
+
 
 AC_CHECK_LIB(pcap, pcap_open_live, [], [echo "error: pcap library not found!"; exit -1])
 AC_CHECK_LIB(sqlite3, sqlite3_open, [], [echo "error: sqlite3 library not found!"; exit -1])

--- a/src/lwe/iwlib.h
+++ b/src/lwe/iwlib.h
@@ -27,10 +27,31 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <netdb.h>		/* gethostbyname, getnetbyname */
+#include <netdb.h>		    /* gethostbyname, getnetbyname */
 #include <net/ethernet.h>	/* struct ether_addr */
 #include <sys/time.h>		/* struct timeval */
 #include <unistd.h>
+#include <stdint.h>
+
+/*
+ * This are types for compatibily
+ */
+#ifdef __linux__
+  #include "linux/types.h"
+  #include <net/if_arp.h>		 /* For ARPHRD_ETHER */
+#else
+
+typedef unsigned char  u_char;
+typedef unsigned short u_short;
+typedef unsigned int   u_int;
+typedef unsigned long  u_long;
+typedef int32_t  __s32;
+typedef uint32_t __u32;
+typedef uint16_t __u16;
+typedef int16_t  __s16;
+typedef uint8_t  __u8;
+
+#endif
 
 /* This is our header selection. Try to hide the mess and the misery :-(
  * Don't look, you would go blind ;-)
@@ -40,18 +61,17 @@
  */
 
 /* Set of headers proposed by Dr. Michael Rietz <rietz@mail.amps.de>, 27.3.2 */
-#include <net/if_arp.h>		/* For ARPHRD_ETHER */
+//
 #include <sys/socket.h>		/* For AF_INET & struct sockaddr */
 #include <netinet/in.h>         /* For struct sockaddr_in */
 #include <netinet/if_ether.h>
+#include <arpa/inet.h>
 
 /* Fixup to be able to include kernel includes in userspace.
  * Basically, kill the sparse annotations... Jean II */
 #ifndef __user
 #define __user
 #endif
-
-#include <linux/types.h>		/* for "caddr_t" et al		*/
 
 /* Glibc systems headers are supposedly less problematic than kernel ones */
 #include <sys/socket.h>			/* for "struct sockaddr" et al	*/

--- a/src/lwe/iwlib.h
+++ b/src/lwe/iwlib.h
@@ -17,8 +17,6 @@
 /***************************** INCLUDES *****************************/
 
 /* Standard headers */
-#include <sys/types.h>
-#include <sys/ioctl.h>
 #include <stdio.h>
 #include <math.h>
 #include <errno.h>
@@ -27,18 +25,28 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <netdb.h>		    /* gethostbyname, getnetbyname */
-#include <net/ethernet.h>	/* struct ether_addr */
-#include <sys/time.h>		/* struct timeval */
 #include <unistd.h>
 #include <stdint.h>
+
+#include <netdb.h>          /* gethostbyname, getnetbyname */
+#include <net/ethernet.h>   /* struct ether_addr */
+#include <net/if.h>         /* for IFNAMSIZ and co... */
+#include <net/if_arp.h>     /* For ARPHRD_ETHER */
+
+#include <netinet/in.h>     /* For struct sockaddr_in */
+#include <netinet/if_ether.h>
+#include <arpa/inet.h>
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>     /* For AF_INET & struct sockaddr */
+#include <sys/time.h>       /* struct timeval */
 
 /*
  * This are types for compatibily
  */
 #ifdef __linux__
   #include "linux/types.h"
-  #include <net/if_arp.h>		 /* For ARPHRD_ETHER */
 #else
 
 typedef unsigned char  u_char;
@@ -56,26 +64,15 @@ typedef uint8_t  __u8;
 /* This is our header selection. Try to hide the mess and the misery :-(
  * Don't look, you would go blind ;-)
  * Note : compatibility with *old* distributions has been removed,
- * you will need Glibc 2.2 and older to compile (which means 
+ * you will need Glibc 2.2 and older to compile (which means
  * Mandrake 8.0, Debian 2.3, RH 7.1 or older).
  */
-
-/* Set of headers proposed by Dr. Michael Rietz <rietz@mail.amps.de>, 27.3.2 */
-//
-#include <sys/socket.h>		/* For AF_INET & struct sockaddr */
-#include <netinet/in.h>         /* For struct sockaddr_in */
-#include <netinet/if_ether.h>
-#include <arpa/inet.h>
 
 /* Fixup to be able to include kernel includes in userspace.
  * Basically, kill the sparse annotations... Jean II */
 #ifndef __user
 #define __user
 #endif
-
-/* Glibc systems headers are supposedly less problematic than kernel ones */
-#include <sys/socket.h>			/* for "struct sockaddr" et al	*/
-#include <net/if.h>			/* for IFNAMSIZ and co... */
 
 /* Private copy of Wireless extensions (in this directoty) */
 #include "wireless.h"


### PR DESCRIPTION
Fixed error: pcap library not found for FreeBSD
```
[xxx@ /reaver-wps-fork-t6x/src]$ ./configure 
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
./configure: FreeBSD: not found
checking for FreeBSD... checking for pcap_open_live in -lpcap... no
error: pcap library not found!
exit: Illegal number: -1
```
