### PR TITLE
Codesmell

### DIFF
--- a/src/libwps/libwps.c
+++ b/src/libwps/libwps.c
@@ -304,24 +304,14 @@ const u_char *libwps_radio_header(const u_char *packet, size_t len)
 /* Convert raw data to a hex string */
 char *hex2str(unsigned char *hex, int len)
 {
-    char *str = NULL;
-    int str_len = 0, i = 0;
-    char tmp_str[3] = { 0 };
-
-    str_len = (len * 2);
-
-    str = malloc(str_len+1);
-    if(str)
-    {
-        memset(str, 0, (str_len+1));
-
-        for(i=0; i<len; i++)
-        {
-            memset((char *) &tmp_str, 0, sizeof(tmp_str));
-            snprintf((char *) &tmp_str, sizeof(tmp_str), "%.2X", hex[i]);
-            strncat(str, (char *) &tmp_str, 2);
-        }
-    }
-
-    return str;
+        static const char atab[] = "0123456789abcdef";
+	char *str = malloc((len*2)+1), *out=str;
+	if(!str) return 0;
+        for(;len;hex++,len--) {
+                *(out++) = atab[*hex >> 4];
+                *(out++) = atab[*hex & 0xf];
+	}
+	*out = 0;
+	return str;
 }
+

--- a/src/misc.c
+++ b/src/misc.c
@@ -36,31 +36,11 @@
 /* Converts a raw MAC address to a colon-delimited string */
 char *mac2str(unsigned char *mac, char delim)
 {
-    int i = 0, str_len = 0;
-    int str_mult = 3;
-    int buf_size = str_mult+1;
-    char *str = NULL;
-    unsigned char buf[4] = { 0 };	/* 4 == buf_size */
-
-    str_len = (MAC_ADDR_LEN * str_mult) + 1;
-
-    str = malloc(str_len);
-    if(!str)
-    {
-        perror("malloc");
-    } else {
-        memset(str, 0, str_len);
-
-        for(i=0; i<MAC_ADDR_LEN; i++)
-        {
-            memset((char *) &buf, 0, buf_size);
-            snprintf((char *) &buf, buf_size, "%.2X%c", mac[i], delim);
-            strncat((char *) str, (char *) &buf, str_mult);
-        }
-        memset(str+((MAC_ADDR_LEN*str_mult)-1), 0, 1);
-    }
-
-    return str;
+	char nyu[6*3];
+#define PAT "%.2X%c"
+#define PRT(X) mac[X], delim
+	snprintf(nyu, sizeof nyu, PAT PAT PAT PAT PAT "%.2X", PRT(0), PRT(1), PRT(2), PRT(3), PRT(4), mac[5]);
+	return strdup(nyu);
 }
 
 /* Converts a colon-delimited string to a raw MAC address */


### PR DESCRIPTION
fix some spots in the code with a strong smell.
these here need to be fixed, too:
```
~/reaver-wps-fork-t6x $ find -name '*.c' | xargs grep 'mem.*char.*&'
./src/lwe/iwlib.c:    memcpy((char *) &sain->sin_addr, (char *) hp->h_addr_list[0], hp->h_length);
./src/lwe/iwlib.c:        memcpy((char *) &(arp_query.arp_pa),
./src/builder.c:            memcpy((void *) ((char *) packet+offset), (void *) &ssid_tag, sizeof(ssid_tag));
./src/session.c:                    memset((char *) &line, 0, MAX_LINE_SIZE);
./src/session.c:                        memset((char *) &line, 0, MAX_LINE_SIZE);
./src/session.c:                                memset((char *) &temp, 0, P1_READ_LEN);
./src/session.c:                                memset((char *) &temp, 0, P1_READ_LEN);
./src/session.c:            memcpy((char *) &file_name, get_session(), FILENAME_MAX-1);
./src/session.c:                    memset((char *) &line, 0, MAX_LINE_SIZE);
./src/session.c:                        memset((char *) &line, 0, MAX_LINE_SIZE);
./src/globule.c:    memcpy((unsigned char *) &globule->bssid, value, MAC_ADDR_LEN);
./src/globule.c:    memcpy((unsigned char *) &globule->mac, value, MAC_ADDR_LEN);
```