### PR TITLE
Fixmac2

### DIFF
--- a/src/globule.c
+++ b/src/globule.c
@@ -430,20 +430,20 @@ int get_channel(void)
 
 void set_bssid(unsigned char *value)
 {
-    memcpy((unsigned char *) &globule->bssid, value, MAC_ADDR_LEN);
+    memcpy(globule->bssid, value, MAC_ADDR_LEN);
 }
 unsigned char *get_bssid()
 {
-    return (unsigned char *) &globule->bssid;
+    return globule->bssid;
 }
 
 void set_mac(unsigned char *value)
 {
-    memcpy((unsigned char *) &globule->mac, value, MAC_ADDR_LEN);
+    memcpy(globule->mac, value, MAC_ADDR_LEN);
 }
 unsigned char *get_mac()
 {
-    return (unsigned char *) &globule->mac;
+    return globule->mac;
 }
 
 void set_ssid(char *value)

--- a/src/misc.c
+++ b/src/misc.c
@@ -39,7 +39,11 @@ char *mac2str(unsigned char *mac, char delim)
 	char nyu[6*3];
 #define PAT "%.2X%c"
 #define PRT(X) mac[X], delim
-	snprintf(nyu, sizeof nyu, PAT PAT PAT PAT PAT "%.2X", PRT(0), PRT(1), PRT(2), PRT(3), PRT(4), mac[5]);
+#define PBT "%.2X"
+	if(delim)
+		snprintf(nyu, sizeof nyu, PAT PAT PAT PAT PAT PBT, PRT(0), PRT(1), PRT(2), PRT(3), PRT(4), mac[5]);
+	else
+		snprintf(nyu, sizeof nyu, PBT PBT PBT PBT PBT PBT, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 	return strdup(nyu);
 }
 

--- a/src/session.c
+++ b/src/session.c
@@ -94,45 +94,45 @@ int restore_session()
             if((fp = fopen(file, "r")))
             {
                 /* Get the key1 index value */
-                if(fgets((char *) &line, MAX_LINE_SIZE, fp) != NULL)
+                if(fgets(line, MAX_LINE_SIZE, fp) != NULL)
                 {
                     set_p1_index(atoi(line));
-                    memset((char *) &line, 0, MAX_LINE_SIZE);
+                    memset(line, 0, MAX_LINE_SIZE);
 
                     /* Get the key2 index value */
-                    if(fgets((char *) &line, MAX_LINE_SIZE, fp) != NULL)
+                    if(fgets(line, MAX_LINE_SIZE, fp) != NULL)
                     {
                         set_p2_index(atoi(line));
-                        memset((char *) &line, 0, MAX_LINE_SIZE);
+                        memset(line, 0, MAX_LINE_SIZE);
 
                         /* Get the key status value */
-                        if(fgets((char *) &line, MAX_LINE_SIZE, fp) != NULL)
+                        if(fgets(line, MAX_LINE_SIZE, fp) != NULL)
                         {
                             set_key_status(atoi(line));
 
                             /* Read in all p1 values */
                             for(i=0; i<P1_SIZE; i++)
                             {
-                                memset((char *) &temp, 0, P1_READ_LEN);
+                                memset(temp, 0, P1_READ_LEN);
 
-                                if(fgets((char *) &temp, P1_READ_LEN, fp) != NULL)
+                                if(fgets(temp, P1_READ_LEN, fp) != NULL)
                                 {
                                     /* NULL out the new line character */
                                     temp[P1_STR_LEN] = 0;
-                                    set_p1(i, (char *) &temp);
+                                    set_p1(i, temp);
                                 }
                             }
 
                             /* Read in all p2 values */
                             for(i=0; i<P2_SIZE; i++)
                             {
-                                memset((char *) &temp, 0, P1_READ_LEN);
+                                memset(temp, 0, P1_READ_LEN);
 
-                                if(fgets((char *) &temp, P2_READ_LEN, fp) != NULL)
+                                if(fgets(temp, P2_READ_LEN, fp) != NULL)
                                 {
                                     /* NULL out the new line character */
                                     temp[P2_STR_LEN] = 0;
-                                    set_p2(i, (char *) &temp);
+                                    set_p2(i, temp);
                                 }
                             }
 
@@ -172,7 +172,7 @@ int save_session()
 
     wps = get_wps();
     bssid = mac2str(get_bssid(), '\0');
-    pretty_bssid = (char *) mac2str(get_bssid(), ':');
+    pretty_bssid = mac2str(get_bssid(), ':');
 
     if(wps)
     {
@@ -203,43 +203,43 @@ int save_session()
              
             if(configuration_directory_exists())
             {
-                snprintf((char *) &file_name, FILENAME_MAX, "%s/%s.%s", CONF_DIR, bssid, CONF_EXT);
+                snprintf(file_name, FILENAME_MAX, "%s/%s.%s", CONF_DIR, bssid, CONF_EXT);
             }
             else
             {
-                snprintf((char *) &file_name, FILENAME_MAX, "%s.%s", bssid, CONF_EXT);
+                snprintf(file_name, FILENAME_MAX, "%s.%s", bssid, CONF_EXT);
             }
             
             
             
             /* save session to the current directory - OpenWRT*/
-			//snprintf((char *) &file_name, FILENAME_MAX, "%s.%s", bssid, CONF_EXT);
+			//snprintf(file_name, FILENAME_MAX, "%s.%s", bssid, CONF_EXT);
         }
 
         /* Don't bother saving anything if nothing has been done */
         if((get_p1_index() > 0) || (get_p2_index() > 0))
         {
-            if((fp = fopen((char *) &file_name, "w")))
+            if((fp = fopen(file_name, "w")))
             {
-                snprintf((char *) &line, MAX_LINE_SIZE, "%d\n", get_p1_index());
-                write_size = strlen((char *) &line);
+                snprintf(line, MAX_LINE_SIZE, "%d\n", get_p1_index());
+                write_size = strlen(line);
 
                 /* Save key1 index value */
-                if(fwrite((char *) &line, 1, write_size, fp) == write_size)
+                if(fwrite(line, 1, write_size, fp) == write_size)
                 {
-                    memset((char *) &line, 0, MAX_LINE_SIZE);
-                    snprintf((char *) &line, MAX_LINE_SIZE, "%d\n", get_p2_index());
-                    write_size = strlen((char *) &line);
+                    memset(line, 0, MAX_LINE_SIZE);
+                    snprintf(line, MAX_LINE_SIZE, "%d\n", get_p2_index());
+                    write_size = strlen(line);
 
                     /* Save key2 index value */
-                    if(fwrite((char *) &line, 1, write_size, fp) == write_size)
+                    if(fwrite(line, 1, write_size, fp) == write_size)
                     {
-                        memset((char *) &line, 0, MAX_LINE_SIZE);
-                        snprintf((char *) &line, MAX_LINE_SIZE, "%d\n", get_key_status());
-                        write_size = strlen((char *) &line);
+                        memset(line, 0, MAX_LINE_SIZE);
+                        snprintf(line, MAX_LINE_SIZE, "%d\n", get_key_status());
+                        write_size = strlen(line);
 
                         /* Save key status value */
-                        if(fwrite((char *) &line, 1, write_size, fp) == write_size)
+                        if(fwrite(line, 1, write_size, fp) == write_size)
                         {
                             /* Save all the p1 values */
                             for(i=0; i<P1_SIZE; i++)


### PR DESCRIPTION
fixes the special use case of mac2str() with zero delimiter (as reported by @YI1992 in https://github.com/t6x/reaver-wps-fork-t6x/commit/46485e8614c2056a2f7562d86b53da10626e468e#commitcomment-20071480 )