### PR TITLE
Empty WPS messages as NACKs option to cover additional APs

### DIFF
--- a/src/exchange.c
+++ b/src/exchange.c
@@ -451,9 +451,17 @@ enum wps_type process_wps_message(const void *data, size_t data_size)
     struct wfa_element_header element = { 0 };
     int i = 0, header_size = sizeof(struct wfa_element_header);
 
+    if (data_size == 0)
+    {
+        /*
+         * Treat zero data length WPS messages as NACKs.
+         * Required for certain APs that emit empty WPS messages in place of NACKs.
+         */
+        type = NACK;
+        set_nack_reason(NO_ERROR);
+    }
     /* Shove data into a wpabuf structure for processing */
-    msg = wpabuf_alloc_copy(data, data_size);
-    if(msg)
+    else if (msg = wpabuf_alloc_copy(data, data_size))
     {
         /* Process the incoming message */
         wps_registrar_process_msg(wps, get_opcode(), msg);


### PR DESCRIPTION
Hi there! A pull request to support additional APs.

Certain APs send empty WPS messages instead of formal NACKs. For example the Belkin F5D7231-4-v3000/ WPS0001.

At present Reaver will hang on M4 indefinitely having failed to recognise this behaviour and expecting additional packets which never arrive:
```
[+] Trying pin ********.
[+] Sending EAPOL START request
[+] Received identity request
[+] Sending identity response
[+] Received M1 message
[+] Sending M2 message
[+] Received M3 message
[+] Sending M4 message
...
```

This patch provides an additional command line option to treat empty WPS messages as NACKs:

`
-M, --empty-message-nack        Treat empty WPS messages as NACKs. Use with -n option. [False]
`

With the desired result:
```
[+] Trying pin ********.
[+] Sending EAPOL START request
[+] Received identity request
[+] Sending identity response
[+] Received M1 message
[+] Sending M2 message
[+] Received M3 message
[+] Sending M4 message
[+] Received WSC NACK (reason: 0x0000)
[+] Sending WSC NACK
...
[+] Trying pin ********.
[+] Sending EAPOL START request
[+] Received identity request
[+] Sending identity response
[+] Received M1 message
[+] Sending M2 message
[+] Received M3 message
[+] Sending M4 message
[+] Received M5 message
[+] Sending M6 message
[+] Received M7 message
[+] Sending WSC NACK
[+] Sending WSC NACK
[+] Pin cracked in * seconds
[+] WPS PIN: '********'
[+] WPA PSK: '********'
[+] AP SSID: '********'
```

It's not clear to me how many other APs exhibit this behaviour or whether you feel this is worth patching in. It's a fairly minimal set of changes although I did take the liberty of clarifying/ tidying a few statements. Either way thank you for continuing to support Reaver.