### PR TITLE
Minor code tidy/ clarification

### DIFF
--- a/src/exchange.c
+++ b/src/exchange.c
@@ -158,12 +158,12 @@ enum wps_result do_wps_exchange()
             case TERMINATE:
                 terminated = 1;
                 break;
+            case UNKNOWN:
+                // cprintf(VERBOSE, "[+] Received UNKNOWN packet\n");
+                break;
             default:
-                if(packet_type != 0)
-                {
-                    cprintf(VERBOSE, "[!] WARNING: Unexpected packet received (0x%.02X), terminating transaction\n", packet_type);
-                    terminated = 1;
-                }
+                cprintf(VERBOSE, "[!] WARNING: Unexpected packet received (0x%.02X), terminating transaction\n", packet_type);
+                terminated = 1;
                 break;
         }
 
@@ -181,7 +181,7 @@ enum wps_result do_wps_exchange()
          * packet, since the timer is started by send_msg. Manually start the timer to
          * prevent infinite loops.
          */
-        else if(packet_type != 0)
+        else if(packet_type != UNKNOWN)
         {
             start_timer();
         }


### PR DESCRIPTION
Follow up from https://github.com/t6x/reaver-wps-fork-t6x/pull/119. Minor code tidying for [exchange.c](https://github.com/t6x/reaver-wps-fork-t6x/blob/707c5749a9dae95ec20e947ca8f07f0eda7b4d8f/src/exchange.c) that give us a clearer indication of the code flow in a critical loop section.

Notably:
```c
            case TERMINATE:
                terminated = 1;
                break;
            default:
                if(packet_type != 0)
                {
                    cprintf(VERBOSE, "[!] WARNING: Unexpected packet received (0x%.02X), terminating transaction\n", packet_type);
                    terminated = 1;
                }
                break;
```
to:
```c
            case TERMINATE:
                terminated = 1;
                break;
            case UNKNOWN:
                // cprintf(VERBOSE, "[+] Received UNKNOWN packet\n");
                break;
            default:
                cprintf(VERBOSE, "[!] WARNING: Unexpected packet received (0x%.02X), terminating transaction\n", packet_type);
                terminated = 1;
                break;
```

I've left the newly introduced `UNKNOWN` verbose notification message commented out as it will likely just spam the user.
