### PR TITLE
Makefile: remove bogus rules

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -12,6 +12,7 @@ DISABLED_WARNINGS= \
  -Wno-pointer-sign
 
 CFLAGS=-DCONF_DIR='"$(CONFDIR)"' @CFLAGS@ $(DISABLED_WARNINGS)
+CFLAGS += $(INC)
 
 WPS_OBJS=wps/wps_attr_build.o wps/wps_attr_parse.o wps/wps_attr_process.o \
 wps/wps.o wps/wps_common.o wps/wps_dev_attr.o wps/wps_enrollee.o \
@@ -53,54 +54,6 @@ tls/libtls.a:
 
 libiw:
 	(cd lwe && make BUILD_STATIC=y libiw.a)
-
-init.o:
-	$(CC) $(CFLAGS) init.c -c
-
-crc.o:
-	$(CC) $(CFLAGS) crc.c -c
-
-keys.o:
-	$(CC) $(CFLAGS) keys.c -c
-
-argsparser.o: globule.o
-	$(CC) $(CFLAGS) $(INC) argsparser.c -c
-
-sigint.o: globule.o
-	$(CC) $(CFLAGS) $(INC) sigint.c -c
-
-exchange.o: globule.o send.o sigalrm.o 80211.o
-	$(CC) $(CFLAGS) $(INC) exchange.c -c
-
-send.o: globule.o builder.o sigalrm.o
-	$(CC) $(CFLAGS) send.c -c
-
-session.o: globule.o
-	$(CC) $(CFLAGS) $(INC) session.c -c
-
-80211.o: globule.o builder.o crc.o
-	$(CC) $(CFLAGS) $(INC) 80211.c -c
-
-iface.o: globule.o
-	$(CC) $(CFLAGS) iface.c -c
-
-sigalrm.o: globule.o
-	$(CC) $(CFLAGS) sigalrm.c -c
-
-misc.o: globule.o 
-	$(CC) $(CFLAGS) misc.c -c
-
-builder.o: globule.o
-	$(CC) $(CFLAGS) builder.c -c
-
-pins.o: globule.o keys.o
-	$(CC) $(CFLAGS) pins.c -c
-
-cracker.o: globule.o init.o pins.o iface.o exchange.o session.o 80211.o
-	$(CC) $(CFLAGS) $(INC) cracker.c -c
-
-globule.o:
-	$(CC) $(CFLAGS) globule.c -c 
 
 install: wash reaver
 	install -D -m 755 wash $(DESTDIR)$(exec_prefix)/bin/wash


### PR DESCRIPTION
They are breaking basic dependencies, like that .o depends on .c,
so are preventing rebuild when .c is changed. Just use implicit
make rule instead.