### PR TITLE
fix stdout when beacon is received

### DIFF
--- a/src/cracker.c
+++ b/src/cracker.c
@@ -74,9 +74,9 @@ void crack()
 		 * We need to get some basic info from the AP, and also want to make sure the target AP
 		 * actually exists, so wait for a beacon packet 
 		 */
-		cprintf(INFO, "[+] Waiting for beacon from %s...", bssid);
-		read_ap_beacon();
-		cprintf(INFO, "OK\n");
+		cprintf(INFO, "[+] Waiting for beacon from %s\n", bssid);  
+		read_ap_beacon();  
+		cprintf(INFO, "[+] Received beacon from %s\n", bssid);
 	
 		/* I'm fairly certian there's a reason I put this in twice. Can't remember what it was now though... */	
 		if(get_max_pin_attempts() == -1)


### PR DESCRIPTION
previous stdout was buggy when no chanel filter was used (check http://pix.toile-libre.org/upload/original/1506595139.png ). It also did not follow reaver design scheme (nromally [+] Received <type of packet> )