### PR TITLE
vendor.c: OUI for Lantiq/Metalink wifi chipsets

### DIFF
--- a/src/utils/vendor.c
+++ b/src/utils/vendor.c
@@ -20,6 +20,7 @@ char *get_vendor_string(const unsigned char* oui) {
 		{"\x00\x50\x43", "MarvellS"}, /* Marvell Semiconductor, Inc. */
 		{"\x00\x26\x86", "Quantenn"}, /* Quantenna */
 		{"\x00\x50\xf2", "Microsof"}  /* Microsoft */
+		{"\x00\x50\xf2", "LantiqME"}  /* Metaklink Lantiq */
 	};
 
 	#define VENDOR_LIST_SIZE (sizeof(vendors)/sizeof(vendors[0]))


### PR DESCRIPTION
   Lantiq - Metalink chipset detection. 
Tested device: 
  * Astoria Networks / Arcadyan ARV7519RW22-A-LT (Orange Livebox 2.1) with Xwave 300 Lantiq psb8231 11 bgn 1a30:0710 (rev 01)
Issue:
  *  Wash does not detect this kind of chipset:
Details: 
result of a basic wash scan 
`88:03:55:XX:XX:XX   11  -54  1.0  No   Unknown   MXXXXXX`
The OUI detected in advanced probe parameters is 00:09:86
`"bssid" : "88:03:55:XX:XX:XX", "essid" : "MXXXXXX", "channel" : 11, "rssi" : -54, "vendor_oui" : "000986"`
It belongs to "metalink"
`00 09 86 Metalink LTD.`
Metalink was bought by Lantiq in 2010. Lantiq itself was bought by Intel in 2015.