### PR TITLE
vendor.c: add detection OUI Lantiq-Metalink

### DIFF
--- a/src/utils/vendor.c
+++ b/src/utils/vendor.c
@@ -20,6 +20,7 @@ char *get_vendor_string(const unsigned char* oui) {
 		{"\x00\x50\x43", "MarvellS"}, /* Marvell Semiconductor, Inc. */
 		{"\x00\x26\x86", "Quantenn"}, /* Quantenna */
 		{"\x00\x50\xf2", "Microsof"}  /* Microsoft */
+		{"\x00\x09\x86", "LantiqME"}  /* Lantiq & Metalink  */
 	};
 
 	#define VENDOR_LIST_SIZE (sizeof(vendors)/sizeof(vendors[0]))


### PR DESCRIPTION
Issue: 
  The wifi chipset of Astoria Networks / Arcadyan ARV7519RW22-A-LT (Orange Livebox 2.1) isn't detected properly
`88:03:55:XX:XX:XX   11  -54  1.0  No   Unknown   NON4M3` 
  The vendor OUI address in advanced parameter belongs to metalink
`"vendor_oui" : "000986"`
  The Wifi chipset is a `Xwave 300 Lantiq psb8231 11 bgn 1a30:0710 (rev 01)`
  Metalink was bought in 2010 by lantiq (which has been bought by intel in 2015)