### PR TITLE
vendor.c: Detect Lantiq/MetaLink chipset

### DIFF
--- a/src/utils/vendor.c
+++ b/src/utils/vendor.c
@@ -19,6 +19,7 @@ char *get_vendor_string(const unsigned char* oui) {
 		{"\x00\x1c\x51", "CelenoCo"}, /* Celeno Communications */
 		{"\x00\x50\x43", "MarvellS"}, /* Marvell Semiconductor, Inc. */
 		{"\x00\x26\x86", "Quantenn"}, /* Quantenna */
+		{"\x00\x09\x86", "LantiqML"}, /* Lantiq/MetaLink */
 		{"\x00\x50\xf2", "Microsof"}  /* Microsoft */
 	};
 


### PR DESCRIPTION
Added vendor OUI 00:09:86 (MetaLink) to detect properly Lantiq WiFi chips such as the "Xwave 300 Lantiq psb8231 11 bgn" from arcadyan ARV7519RW22 (livebox 2.1).
FYI MetaLink was bought by Lantiq in 2010 which explains why they have the same OUI