### PR TITLE
Fix wrong arbitrary pin

### DIFF
--- a/src/argsparser.c
+++ b/src/argsparser.c
@@ -285,7 +285,6 @@ void parse_static_pin(char *pin)
 		{
 			memcpy((void *) &p1, pin, sizeof(p1)-1);
 			set_static_p1((char *) &p1);
-			set_key_status(KEY2_WIP);
 
 			if(len > 4)
 			{

--- a/src/cracker.c
+++ b/src/cracker.c
@@ -40,6 +40,7 @@ void crack()
 	char *bssid = NULL;
 	char *pin = NULL;
 	int fail_count = 0, loop_count = 0, sleep_count = 0, assoc_fail_count = 0;
+	int session_restored;
 	float pin_count = 0;
 	time_t start_time = 0;
 	enum wps_result result = 0;
@@ -63,9 +64,14 @@ void crack()
 		generate_pins();
 
 		/* Restore any previously saved session */
-		if(get_static_p1() == NULL)
+		if(get_static_p1() == NULL || !get_pin_string_mode())
 		{
-			restore_session();
+			session_restored = restore_session();
+			/* Check arbitrary pin has been already tried */
+			if (session_restored == -1)
+			{
+				return;
+			}
 		}
 
 		/* Convert BSSID to a string */

--- a/src/keys.c
+++ b/src/keys.c
@@ -11040,3 +11040,59 @@ struct key k2[P2_SIZE] = {
 		{ "998", 0 },
 		{ "999", 1 }
 };
+
+/**
+ * Return the index of k1[].key of p1 values
+ * 
+ * @params int* value The value of p1 key
+ * 
+ * @return int        The index of value in k1
+ */
+int get_k1_key_index(int value)
+{
+	int i;
+	int indexs[3];
+	char str_pin[12];
+
+	indexs[0] = value; /* In k1, value == index is 87.66% */
+	indexs[1] = value+1; /* In k1, value+1 == index is 12.33% */
+	indexs[2] = 0; /* In k1, value in index 0 is 0.01% (1234) */
+	for (i=0; i<3; ++i){
+		if (indexs[i] >= 0 && indexs[i] < P1_SIZE){
+			sprintf(str_pin, "%04d", value);
+			if (strcmp(k1[indexs[i]].key, str_pin) == 0) {
+				return indexs[i];
+			}
+		}
+	}
+
+	return -1; /* not found */
+}
+
+/**
+ * Return the index of k2[].key of p2 values
+ * 
+ * @params int* value The value of p2 key
+ * 
+ * @return int        The index of k2
+ */
+int get_k2_key_index(int value)
+{
+	int i;
+	int indexs[3];
+	char str_pin[12];
+
+	indexs[0] = value+1; /* In k2, value+1 == index is 56.6% */
+	indexs[1] = value; /* In k2, value == index is 43.3% */
+	indexs[2] = 0; /* In k2, value in index 0 is 0.1% (567) */
+	for (i=0; i<3; ++i){
+		if (indexs[i] >= 0 && indexs[i] < P2_SIZE){
+			sprintf(str_pin, "%03d", value);
+			if (strcmp(k2[indexs[i]].key, str_pin) == 0) {
+				return indexs[i];
+			}
+		}
+	}
+
+	return -1; /* not found */
+}

--- a/src/keys.h
+++ b/src/keys.h
@@ -42,4 +42,7 @@ struct key
         int priority;
 };
 
+int get_k1_key_index(int value);
+int get_k2_key_index(int value);
+
 #endif

--- a/src/pins.c
+++ b/src/pins.c
@@ -102,14 +102,21 @@ void generate_pins()
 {
         int i = 0, index = 0;
 
-	/* If the first half of the pin was not specified, generate a list of possible pins */
-	if(!get_static_p1())
+	/* If the first half of the pin was specified,
+	 * generate a list of possible pins with the specified first half pin first
+	 */
+	if(get_static_p1() && !get_pin_string_mode())
 	{
+		i = get_k1_key_index(atoi(get_static_p1()));
+		set_p1(index, k1[i].key);
+		k1[i].priority = 2;
+		index++;
+	}
 		/* 
 		 * Look for P1 keys marked as priority. These are pins that have been 
 		 * reported to be commonly used on some APs and should be tried first. 
 		 */
-		for(index=0, i=0; i<P1_SIZE; i++)
+		for(i=0; i<P1_SIZE; i++)
 		{
 			if(k1[i].priority == 1)
 			{
@@ -127,24 +134,23 @@ void generate_pins()
 	                        index++;
 			}
 		}
-        }
-	else
-	{
-		/* If the first half of the pin was specified by the user, only use that */
-		for(index=0; index<P1_SIZE; index++)
-		{
-			set_p1(index, get_static_p1());
-		}
-	}
 
-	/* If the second half of the pin was not specified, generate a list of possible pins */
-	if(!get_static_p2())
+	/* If the second half of the pin was specified,
+	 * generate a list of possible pins with the specified second half pin first
+	 */
+	index = 0;
+	if(get_static_p2() && !get_pin_string_mode())
 	{
+		i = get_k2_key_index(atoi(get_static_p2()));
+		set_p2(index, k2[i].key);
+		k2[i].priority = 2;
+		index++;
+	}
 		/* 
 		 * Look for P2 keys statically marked as priority. These are pins that have been 
 		 * reported to be commonly used on some APs and should be tried first. 
 		 */
-		for(index=0, i=0; i<P2_SIZE; i++)
+		for(i=0; i<P2_SIZE; i++)
 		{
 			if(k2[i].priority == 1)
 			{
@@ -162,15 +168,6 @@ void generate_pins()
                 	        index++;
 			}
                 }
-        }
-	else
-	{
-		/* If the second half of the pin was specified by the user, only use that */
-		for(index=0; index<P2_SIZE; index++)
-		{
-			set_p2(index, get_static_p2());
-		}
-	}
 
         return;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -60,6 +60,7 @@ int restore_session()
 	char answer = 0;
 	FILE *fp = NULL;
 	int ret_val = 0, i = 0;
+	int add, p1_tried, p2_tried;
 
 	/* 
 	 * If a session file was explicitly specified, use that; else, check for the 
@@ -128,6 +129,7 @@ int restore_session()
 							set_key_status(atoi(line));
 
 							/* Read in all p1 values */
+							add = p1_tried = 0;
 							for(i=0; i<P1_SIZE; i++)
 							{
 								memset(temp, 0, P1_READ_LEN);
@@ -136,11 +138,48 @@ int restore_session()
 								{
 									/* NULL out the new line character */
 									temp[P1_STR_LEN] = 0;
-									set_p1(i, temp);
+									/* check has first half pin was specified and yet is KEY1_WIP */
+									if (get_static_p1() && get_key_status() < KEY2_WIP)
+									{
+										if (i < get_p1_index())
+										{
+											/* Check the first half has been already tried */
+											if (strcmp(get_static_p1(), temp) == 0)
+											{
+												p1_tried = 1;
+											}
+										}
+										else if (i == get_p1_index())
+										{
+											/* Check current index of first half is the specified pin
+											 * Yes: do nothing
+											 * No: insert into current index and set add to 1
+											 */
+											if (!p1_tried && strcmp(get_static_p1(), temp) != 0)
+											{
+												set_p1(i, get_static_p1());
+												add = 1;
+											}
+										}
+										else
+										{
+											/* Check former index of first half
+											 * Yes: set add to 0 and continue to next loop;
+											 * No: do nothing
+											 */
+											if (strcmp(get_static_p1(), temp) == 0)
+											{
+												add = 0;
+												continue;
+											}
+										}
+									}
+									set_p1(i+add, temp);
 								}
 							}
 
 							/* Read in all p2 values */
+							add = p2_tried = 0;
 							for(i=0; i<P2_SIZE; i++)
 							{
 								memset(temp, 0, P1_READ_LEN);
@@ -149,11 +188,65 @@ int restore_session()
 								{
 									/* NULL out the new line character */
 									temp[P2_STR_LEN] = 0;
-									set_p2(i, temp);
+									/* check has second half pin was specified and yet not KEY_DONE */
+									if (get_static_p2() && get_key_status() != KEY_DONE)
+									{
+										if (i < get_p2_index())
+										{
+											/* Check the second half has been already tried */
+											if (strcmp(get_static_p2(), temp) == 0)
+											{
+												p2_tried = 1;
+											}
+										}
+										else if (i == get_p2_index())
+										{
+											/* Check current index of second half is the specified pin
+											 * Yes: do nothing
+											 * No: insert into current index and set add to 1
+											 */
+											if (!p2_tried && strcmp(get_static_p2(), temp) != 0)
+											{
+												set_p2(i, get_static_p2());
+												add = 1;
+											}
+										}
+										else
+										{
+											/* Check former index of second half
+											 * Yes: set add to 0 and continue to next loop;
+											 * No: do nothing
+											 */
+											if (strcmp(get_static_p2(), temp) == 0)
+											{
+												add = 0;
+												continue;
+											}
+										}
+									}
+									set_p2(i+add, temp);
 								}
 							}
 
 							ret_val = 1;
+							/* Check the arbitrary pin has been already tried */
+							if (get_static_p1())
+							{
+								if (p1_tried || p2_tried)
+								{
+									ret_val = -1;
+								}
+								/* Print message what first half pin ignored if former key status >= KEY2_WIP */
+								if (get_key_status() >= KEY2_WIP && strcmp(get_static_p1(), get_p1(get_p1_index())) != 0)
+								{
+									cprintf(INFO, "[!] First half PIN ignored, it was cracked\n");
+								}
+								/* Print message what second half pin ignored if former key status == KEY_DONE */
+								if (get_key_status() == KEY_DONE && strcmp(get_static_p2(), get_p2(get_p2_index())) != 0)
+								{
+									cprintf(INFO, "[!] Second half PIN ignored, it was cracked\n");
+								}
+							}
 						}
 					}
 				}
@@ -172,6 +265,10 @@ int restore_session()
 		set_p1_index(0);
 		set_p2_index(0);
 		set_key_status(KEY1_WIP);
+	}
+	else if(ret_val == -1)
+	{
+		cprintf(CRITICAL, "[!] The PIN has already been tested\n");
 	} else {
 		cprintf(INFO, "[+] Restored previous session\n");
 	}
@@ -229,7 +326,8 @@ int save_session()
 		}
 
 		/* Don't bother saving anything if nothing has been done */
-		if((get_p1_index() > 0) || (get_p2_index() > 0))
+		/* Save .wpc file when the first pin is correct */
+		if((get_p1_index() > 0) || (get_p2_index() > 0) || (get_key_status() == KEY_DONE))
 		{
 			if((fp = fopen(file_name, "w")))
 			{


### PR DESCRIPTION
Problems:
When a wrong arbitrary pin is used, reaver builds wrong pins in loop.
When a half pin increments up until maximum size, increment stop and the last half pin in loop.


Solutions:
- Stop attack if first half pin is wrong (arbitrary 4/7/8 digit);
- Stop attack if second half pin is wrong (arbitrary 7/8 digit);
- Stop attack if session is restored and first half pin is wrong (may be router's pin was changed);
- Save session wpc file also if get_key_status()==KEY_DONE, the objective is save the pin if first attempt is correct;
- Check and set static_p1 and/or static_p2 when static session is restored;
- Restart increment to 0 and set key status to KEY1_WIP if p1 or p2 up until maximum size.


Tests with:
MAC of Router: 00:16:3E:17:08:73, pin: 15094919

reaver -i wlan0mon -b 00:16:3E:17:08:73 -c 4 -vv -N -p 1508     (first half pin is wrong)
Before: loop with pin 1508xxxx (wrong pin), after interrupt (CTRL+C) *.wpc file is saved.
Now: stop attack after NACK and nothing to save.

reaver -i wlan0mon -b 00:16:3E:17:08:73 -c 4 -vv -N -p 1509490  (second half pin is wrong)
Before: loop with pin 15084902, after interrupt (CTRL+C) *.wpc file is saved.
Now: stop attack after NACK and nothing to save.


reaver -i wlan0mon -b 00:16:3E:17:08:73 -c 4 -vv -N -p 15094902 (full pin, but second half pin is wrong)
Before: loop with pin 15094902, after interrupt (CTRL+C) *.wpc file is saved.
Now: stop attack after NACK and nothing to save.

reaver -i wlan0mon -b 00:16:3E:17:08:73 -c 4 -vv -N -p 15094919 (correct pin)
Before: stop attack after get password and nothing to save.
Now: stop attack after get password and *.wpc file is saved for future usage without "-p xxxxxxxx" to discover the forgotten password or new password.

reaver -i wlan0mon -b 00:16:3E:17:08:73 -c 4 -vv -N (without arbitrary pin and we answer "yes")
Before: former session is restored, but without checking if the first half and second half are static.
Now: former session is restored, does checking static half pin, if positive so set static_p1 and/or static_p2.