### PR TITLE
wash: show crack progress with -p option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Optional Arguments:
 	-u, --survey                         Use survey mode [default]
 	-a, --all                            Show all APs, even those without WPS
 	-j, --json                           print extended WPS info as json
+	-p, --progress                       Show percentage of crack progress
 	-h, --help                           Show help
 
 Example:

--- a/src/libwps/libwps.c
+++ b/src/libwps/libwps.c
@@ -37,7 +37,7 @@ static char* append_and_free(char* s1, char *s2, int who) {
 	return new;
 }
 
-char *wps_data_to_json(const char*bssid, const char *ssid, int channel, int rssi, const unsigned char* vendor, struct libwps_data *wps) {
+char *wps_data_to_json(const char*bssid, const char *ssid, int channel, int rssi, const unsigned char* vendor, struct libwps_data *wps, const char *progress) {
 	size_t ol = 0, nl = 0, ns = 0;
 	char *json_str = 0, *old = strdup("{"), *tmp;
 	char buf[1024];
@@ -169,6 +169,11 @@ char *wps_data_to_json(const char*bssid, const char *ssid, int channel, int rssi
 		tmp = sanitize_string(wps->rf_bands);
 		nl = snprintf(buf, sizeof buf, "\"wps_rf_bands\" : \"%s\", ", tmp);
 		free(tmp);
+		json_str = append_and_free(old, buf, 1);
+		old = json_str;
+	}
+	if(progress) {
+		nl = snprintf(buf, sizeof buf, "\"progress\" : \"%s\", ", progress);
 		json_str = append_and_free(old, buf, 1);
 		old = json_str;
 	}

--- a/src/libwps/libwps.h
+++ b/src/libwps/libwps.h
@@ -51,7 +51,7 @@ struct libwps_data
 };
 
 int parse_wps_parameters(const u_char *packet, size_t len, struct libwps_data *wps);
-char *wps_data_to_json(const char*bssid, const char *ssid, int channel, int rssi, const unsigned char* vendor, struct libwps_data *wps);
+char *wps_data_to_json(const char*bssid, const char *ssid, int channel, int rssi, const unsigned char* vendor, struct libwps_data *wps, const char *progress);
 
 #ifdef LIBWPS_C
 

--- a/src/session.c
+++ b/src/session.c
@@ -422,7 +422,7 @@ char *get_crack_progress(unsigned char *mac)
 	struct stat wpstat = { 0 };
 	FILE *fp = NULL;
 	char file[FILENAME_MAX];
-	int p1, p2, p1_idx, p2_idx, i, num, attempts;
+	int p1_idx, p2_idx, num, attempts;
 	char *bssid = NULL, *crack_progress = NULL;
 	enum key_state key_status;
 
@@ -440,21 +440,6 @@ char *get_crack_progress(unsigned char *mac)
 				fscanf(fp, "%d", &num);
 				key_status = num;
 
-				p1 = p2 = 0;
-				for (i = 0; i < P1_SIZE; ++i) {
-					if (i == p1_idx) {
-						fscanf(fp, "%d", &p1);
-					} else {
-						fscanf(fp, "%d", &num);
-					}
-				}
-				for (i = 0; i < P2_SIZE; ++i) {
-					if (i == p2_idx) {
-						fscanf(fp, "%d", &p2);
-					} else {
-						fscanf(fp, "%d", &num);
-					}
-				}
 				fclose(fp);
 
 				if (key_status == KEY1_WIP) {
@@ -464,8 +449,7 @@ char *get_crack_progress(unsigned char *mac)
 					attempts = P1_SIZE + p2_idx + 1;
 					sprintf(crack_progress, "%.2lf", (attempts*100.0)/(P1_SIZE + P2_SIZE));
 				} else {
-					attempts = P1_SIZE + P2_SIZE;
-					sprintf(crack_progress, "%.1lf", (attempts*100.0)/(P1_SIZE + P2_SIZE));
+					sprintf(crack_progress, "%.1lf", 100.0);
 				}
 			} else {
 				if (crack_progress) {

--- a/src/session.h
+++ b/src/session.h
@@ -54,5 +54,6 @@
 
 int restore_session();
 int save_session();
+char *get_crack_progress(unsigned char *mac);
 
 #endif

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -352,7 +352,7 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 	{
 		if(!json_mode) {
 			if (show_crack_progress) {
-				fprintf  (stdout, "BSSID              Ch dBm WPS Lck Vendor       %% ESSID\n");
+				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    Prcnt  ESSID\n");
 			} else {
 				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID\n");
 			}
@@ -472,14 +472,14 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 					if(wps_active(wps))
 					{
 						if (show_crack_progress)
-							fprintf(stdout, "%17s %3d %.2d %d.%d %3s %8s %5s %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
+							fprintf(stdout, "%17s  %3d  %.2d  %d.%d  %3s  %8s  %5s  %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
 						else
 							fprintf(stdout, "%17s  %3d  %.2d  %d.%d  %3s  %8s  %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", sane_ssid);
 					}
 					else
 					{
 						if (show_crack_progress)
-							fprintf(stdout, "%17s %3d %.2d         %8s %5s %s\n", bssid, channel, rssi, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
+							fprintf(stdout, "%17s  %3d  %.2d            %8s  %5s  %s\n", bssid, channel, rssi, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
 						else
 							fprintf(stdout, "%17s  %3d  %.2d            %8s  %s\n", bssid, channel, rssi, vendor ? vendor : "        ", sane_ssid);
 					}

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -354,7 +354,7 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 			if (show_crack_progress) {
 				fprintf  (stdout, "BSSID              Ch dBm WPS Lck Vendor       %% ESSID\n");
 			} else {
-			fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID\n");
+				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID\n");
 			}
 			//fprintf(stdout, "00:11:22:33:44:55  104  -77  1.0  Yes  Bloatcom  0123456789abcdef0123456789abcdef\n");
 			fprintf  (stdout, "--------------------------------------------------------------------------------\n");
@@ -474,14 +474,14 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 						if (show_crack_progress)
 							fprintf(stdout, "%17s %3d %.2d %d.%d %3s %8s %5s %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
 						else
-						fprintf(stdout, "%17s  %3d  %.2d  %d.%d  %3s  %8s  %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", sane_ssid);
+							fprintf(stdout, "%17s  %3d  %.2d  %d.%d  %3s  %8s  %s\n", bssid, channel, rssi, (wps->version >> 4), (wps->version & 0x0F), lock_display, vendor ? vendor : "        ", sane_ssid);
 					}
 					else
 					{
 						if (show_crack_progress)
 							fprintf(stdout, "%17s %3d %.2d         %8s %5s %s\n", bssid, channel, rssi, vendor ? vendor : "        ", crack_progress ? crack_progress : "-", sane_ssid);
 						else
-						fprintf(stdout, "%17s  %3d  %.2d            %8s  %s\n", bssid, channel, rssi, vendor ? vendor : "        ", sane_ssid);
+							fprintf(stdout, "%17s  %3d  %.2d            %8s  %s\n", bssid, channel, rssi, vendor ? vendor : "        ", sane_ssid);
 					}
 					free(sane_ssid);
 

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -352,7 +352,7 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 	{
 		if(!json_mode) {
 			if (show_crack_progress) {
-				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    Prcnt  ESSID\n");
+				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    Progr  ESSID\n");
 			} else {
 				fprintf  (stdout, "BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID\n");
 			}

--- a/src/wpsmon.h
+++ b/src/wpsmon.h
@@ -46,6 +46,7 @@
 #include "iface.h"
 #include "80211.h"
 #include "builder.h"
+#include "session.h"
 
 #define INTERFACE       	0
 #define PCAP_FILE       	1


### PR DESCRIPTION
I beleave this option helps the user to choose which router is better to start or to continue the attack.

	root@kali:~# wash -i wlan0mon -p
	BSSID               Ch  dBm  WPS  Lck  Vendor    ESSID
	--------------------------------------------------------------------------------
	4C:D0:8A:**:**:**    1  -87  2.0  No   Broadcom  AP-ele (0.04%)
	10:C2:5A:**:**:**    1  -83  2.0  No   Broadcom  AP-dinhas 
	18:D6:C7:**:**:**    1  -86  1.0  No   AtherosC  AP-RA (21981333)
	D4:2C:0F:**:**:**    1  -84  2.0  No   Broadcom  AP-no (0.03%)
	E0:41:36:**:**:**    4  -70  1.0  No   RalinkTe  AP-O NPPO (54627345)
	74:EA:3A:**:**:**    4  -75  1.0  No   AtherosC  AP-rizsh3 (98107841)
	E4:C1:46:**:**:**    6  -83  1.0  No   RealtekS  AP--E3B4 (91.11%)
	88:6A:E3:**:**:**    6  -86  2.0  No   RalinkTe  AP-O-3496
	AC:C6:62:**:**:**    8  -87  2.0  No   Broadcom  AP-OCACIA SUNAME
	80:3F:5D:**:**:**   11  -88  2.0  No   RealtekS  AP-etidor-somename
	58:10:8C:**:**:**   11  -87  2.0  No   RealtekS  AP-io Repetidor
	B4:2A:0E:**:**:**   11  -67  2.0  No   Broadcom  AP-_2G7436 (11.26%)

Router without session, just shows the ESSID
Router with session and yet not found the PIN, shows the ESSID and concatenates the percentage in parentheses (x.xx%)
Router with session and the PIN was found, shows the ESSID concatenates the PIN in parentheses (12345670)

To concatenate with the ESSID because the majority of ESSIDs are short