### PR TITLE
Add 'uninstall' make rule

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -143,6 +143,9 @@ install: wash reaver
 	@# if not found defaults to "." i.e. current dir
 	$(MKDIRP) $(DESTDIR)$(CONFDIR)
 
+uninstall:
+	rm -rf $(DESTDIR)$(CONFDIR) $(DESTDIR)$(exec_prefix)/bin/wash $(DESTDIR)$(exec_prefix)/bin/reaver
+
 clean:
 	rm -f reaver wash
 	rm -f $(LIB_OBJS) $(PROG_OBJS)


### PR DESCRIPTION
Hello! I've been trying to automate some wifi tool installation and I've noticed the makefile does not have a 'make uninstall' rule so I've added one, rather than create an issue. Feel free to edit/reject this if it has issues, but I would like to have a rule to delete the files 'make install' creates.