### PR TITLE
wps_attr_parse.c: fix build on m68k

### DIFF
--- a/src/wps/wps_attr_parse.c
+++ b/src/wps/wps_attr_parse.c
@@ -444,7 +444,7 @@ int wps_parse_msg(const struct wpabuf *msg, struct wps_parse_attr *attr)
 			 * end of M1. Skip those to avoid interop issues.
 			 */
 			int i;
-			for (i = 0; i < end - pos; i++) {
+			for (i = 0; i < (u8)(end - pos); i++) {
 				if (pos[i])
 					break;
 			}


### PR DESCRIPTION
Static build on m68k fails on:
/accts/mlweber1/rclinux/rc-buildroot-test/scripts/instance-0/output/host/bin/m68k-linux-gcc -DCONF_DIR='"/var/lib/reaver"' -Wall -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os   -fno-dwarf2-cfi-asm -Wl,-elf2flt -static -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-function -Wno-pointer-sign -Ilibwps -I. -Ilwe -DCONFIG_IPV6 -I. -Iutils   -c -o wps/wps_dev_attr.o wps/wps_dev_attr.c
/tmp/ccC02tia.s: Assembler messages:
/tmp/ccC02tia.s:899: Error: value -216 out of range
/tmp/ccC02tia.s:899: Error: value of -216 too large for field of 1 bytes at 1977
make[1]: *** [wps/wps_attr_parse.o] Error 1

To fix this issue, statically cast end - pos to u8

Fixes:
 - http://autobuild.buildroot.org/results/935c038b921ffa0f185571de41223e4c201e964b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>