### PR TITLE
wash: fix calculation of attack progress

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -341,13 +341,13 @@ char *get_crack_progress(unsigned char *mac)
 	char *bssid = NULL, *crack_progress = NULL;
 	enum key_state key_status;
 
-	bssid = (char *) mac2str(mac, '\0');
+	bssid = mac2str(mac, '\0');
 
 	if (bssid) {
 		gen_sessionfile_name(bssid, file);
 
 		if(stat(file, &wpstat) == 0) {
-			crack_progress = (char*) malloc(10);
+			crack_progress = malloc(10);
 			if((fp = fopen(file, "r")) && crack_progress) {
 				crack_progress[0] = '\0';
 				fscanf(fp, "%d", &p1_idx);

--- a/src/session.c
+++ b/src/session.c
@@ -358,10 +358,10 @@ char *get_crack_progress(unsigned char *mac)
 				fclose(fp);
 
 				if (key_status == KEY1_WIP) {
-					attempts = p1_idx + 1;
+					attempts = p1_idx;
 					sprintf(crack_progress, "%.2lf", (attempts*100.0)/(P1_SIZE + P2_SIZE));
 				} else if (key_status == KEY2_WIP) {
-					attempts = P1_SIZE + p2_idx + 1;
+					attempts = P1_SIZE + p2_idx;
 					sprintf(crack_progress, "%.2lf", (attempts*100.0)/(P1_SIZE + P2_SIZE));
 				} else {
 					sprintf(crack_progress, "%.1lf", 100.0);


### PR DESCRIPTION
My mistake, the calculation of progress was wrong, correct not need plus 1.
Example of a .wpc file (first 3 lines):
```
1
0
0
```
It's 1/11000 (0.01%) is done and not 2/11000 (0.02%)

Even for:
```
0
999
1
```
It is 10999/11000 (99.99%) is done and not 11000/11000 (100.0%)

removed unnecessary type cast too.
