### PR TITLE
save .wpc file if the first half of first pin is correct

### DIFF
--- a/src/session.c
+++ b/src/session.c
@@ -328,8 +328,8 @@ int save_session()
 		}
 
 		/* Don't bother saving anything if nothing has been done */
-		/* Save .wpc file when the first pin is correct */
-		if((get_p1_index() > 0) || (get_p2_index() > 0) || (get_key_status() == KEY_DONE))
+		/* Save .wpc file if the first half of first pin is correct */
+		if((get_p1_index() > 0) || (get_p2_index() > 0) || (get_key_status() >= KEY2_WIP))
 		{
 			if((fp = fopen(file_name, "w")))
 			{


### PR DESCRIPTION
Example of a situation:
In the first attempt it fails to complete the authentication, but "m5" is received, so 90.91% is done, and at this point the user sends CTRL+C and nothing has been saved.
As 90.91% is done, then it is good to save in .wpc file.