### PR TITLE
Decrease definition of EAPOL_START_MAX_TRIES

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -76,7 +76,7 @@
 #define P1_SIZE			10000
 #define P2_SIZE			1000
 
-#define EAPOL_START_MAX_TRIES	25
+#define EAPOL_START_MAX_TRIES	10
 #define WARN_FAILURE_COUNT	10
 
 #define EAPOL_START		1


### PR DESCRIPTION
Decrease definition of EAPOL_START_MAX_TRIES to speed up the attack.
Often times need to wait 25 times timeout to reassociate.
Decreasing to 10 can save up to 60% of the waiting time until reassociating.
Is number 10 good?