### PR TITLE
Replace obsolete ualarm with setitimer

### DIFF
--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -329,11 +329,7 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 		{
         		act.sa_handler = sigalrm_handler;
         		sigaction (SIGALRM, &act, 0);
-			struct itimerval timer;
-            timer.it_value.tv_sec = 0;
-			timer.it_value.tv_usec = CHANNEL_INTERVAL;
-            timer.it_interval.tv_sec = 0;
-			timer.it_interval.tv_usec = CHANNEL_INTERVAL;
+			struct itimerval timer = {.it_value.tv_usec = CHANNEL_INTERVAL, .it_interval.tv_usec = CHANNEL_INTERVAL};
 			setitimer(ITIMER_REAL, &timer, NULL);
 			int startchan = 1;
 			if(get_wifi_band() == AN_BAND)
@@ -435,11 +431,7 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 
 			if(target != NULL && channel_changed == 0)
 			{
-				struct itimerval timeroff;
-                timeroff.it_value.tv_sec = 0;
-				timeroff.it_value.tv_usec = 0;
-                timeroff.it_interval.tv_sec = 0;
-				timeroff.it_interval.tv_usec = 0;
+				struct itimerval timeroff = {0};
 				setitimer(ITIMER_REAL, &timeroff, NULL);
 				change_channel(channel);
 				channel_changed = 1;

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -330,9 +330,11 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
         		act.sa_handler = sigalrm_handler;
         		sigaction (SIGALRM, &act, 0);
 			struct itimerval timer;
+            timer.it_value.tv_sec = 0;
 			timer.it_value.tv_usec = CHANNEL_INTERVAL;
+            timer.it_interval.tv_sec = 0;
 			timer.it_interval.tv_usec = CHANNEL_INTERVAL;
-			setitimer(ITIMER_REAL, &timer, &timer);
+			setitimer(ITIMER_REAL, &timer, NULL);
 			int startchan = 1;
 			if(get_wifi_band() == AN_BAND)
 				startchan = 34;
@@ -434,9 +436,11 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 			if(target != NULL && channel_changed == 0)
 			{
 				struct itimerval timeroff;
+                timeroff.it_value.tv_sec = 0;
 				timeroff.it_value.tv_usec = 0;
+                timeroff.it_interval.tv_sec = 0;
 				timeroff.it_interval.tv_usec = 0;
-				setitimer(ITIMER_REAL, &timeroff, &timeroff);
+				setitimer(ITIMER_REAL, &timeroff, NULL);
 				change_channel(channel);
 				channel_changed = 1;
 			}

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -329,7 +329,10 @@ void monitor(char *bssid, int passive, int source, int channel, int mode)
 		{
         		act.sa_handler = sigalrm_handler;
         		sigaction (SIGALRM, &act, 0);
-			ualarm(CHANNEL_INTERVAL, CHANNEL_INTERVAL);
+			struct itimerval timer;
+			timer.it_value.tv_usec = CHANNEL_INTERVAL;
+			timer.it_interval.tv_usec = CHANNEL_INTERVAL;
+			setitimer(ITIMER_REAL, &timer, &timer);
 			int startchan = 1;
 			if(get_wifi_band() == AN_BAND)
 				startchan = 34;
@@ -430,7 +433,10 @@ void parse_wps_settings(const u_char *packet, struct pcap_pkthdr *header, char *
 
 			if(target != NULL && channel_changed == 0)
 			{
-				ualarm(0, 0);
+				struct itimerval timeroff;
+				timeroff.it_value.tv_usec = 0;
+				timeroff.it_interval.tv_usec = 0;
+				setitimer(ITIMER_REAL, &timeroff, &timeroff);
 				change_channel(channel);
 				channel_changed = 1;
 			}


### PR DESCRIPTION
Unfortunately, I don't have the proper programming skills for POSIX, but I really want to run Reaver in Termux on Android. `ualarm` is not available in Bionic libc, which is used in Android NDK. I also found out that `ualarm` is obsolete and was removed in the POSIX.1-2008 specification (https://man7.org/linux/man-pages/man3/ualarm.3.html)
If my fixes are incorrect, please help anyone who understands programming for POSIX.
Also see https://github.com/t6x/reaver-wps-fork-t6x/issues/255