### PR TITLE
wash: fix loop when exhausted the maximum number of bssid's cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Main developer since version 1.6b:
 `rofl0r`  
 
 Modifications made by:
-`t6_x`, `DataHead`, `Soxrok2212`, `Wiire`, `AAnarchYY`, `kib0rg`, `KokoSoft`, `rofl0r`, `horrorho`, `binarymaster`, `Ǹotaz`, `Adde88`  
+`t6_x`, `DataHead`, `Soxrok2212`, `Wiire`, `AAnarchYY`, `kib0rg`, `KokoSoft`, `rofl0r`, `horrorho`, `binarymaster`, `Ǹotaz`, `Adde88`, `feitoi`
 
 Some ideas made by:
 `nuroo`, `kcdtv`

--- a/src/libwps/libwps.c
+++ b/src/libwps/libwps.c
@@ -14,7 +14,6 @@
 #include "libwps.h"
 #include "../utils/common.h"
 #include "../cprintf.h"
-#include "../crc.h"
 #include <assert.h>
 
 static char* append(char* s1, char *s2) {
@@ -235,8 +234,6 @@ static int parse_wps_tags(const u_char *tags, size_t len,
 
 	if(wps_ie_data)
 	{
-		wps->checksum = crc32(wps_ie_data, wps_data_len);
-
 		for(i=0; i<sizeof(elements)/sizeof(elements[0]); i++)
 		{
 			/* Search for each WPS element inside the WPS IE data blob */

--- a/src/libwps/libwps.h
+++ b/src/libwps/libwps.h
@@ -35,7 +35,6 @@ struct libwps_data
         uint8_t version;
         uint8_t state;
         uint8_t locked;
-	uint32_t checksum;
         char manufacturer[LIBWPS_MAX_STR_LEN];
         char model_name[LIBWPS_MAX_STR_LEN];
         char model_number[LIBWPS_MAX_STR_LEN];

--- a/src/wpsmon.c
+++ b/src/wpsmon.c
@@ -65,7 +65,10 @@ static int list_insert(char *bssid) {
 	str2mac(bssid, mac);
 	for(i=0; i<seen_count; i++)
 		if(!memcmp(seen_list[i].mac, mac, 6)) return i;
-	if(seen_count >= MAX_APS) return -1;
+	if(seen_count >= MAX_APS) {
+		memset(seen_list, 0, sizeof seen_list);
+		seen_count = 0;
+	}
 	memcpy(seen_list[seen_count].mac, mac, 6);
 	return seen_count++;
 }
@@ -76,7 +79,7 @@ static int was_printed(char* bssid) {
 		seen_list[x].flags |= SEEN_FLAG_PRINTED;
 		return f & SEEN_FLAG_PRINTED;
 	}
-	return 0;
+	return 1;
 }
 static void mark_ap_complete(char *bssid) {
 	int x = list_insert(bssid);
@@ -95,7 +98,7 @@ static int is_done(char *bssid, struct libwps_data *wps) {
 		}
 		return seen_list[x].flags & SEEN_FLAG_COMPLETE;
 	}
-	return 0;
+	return 1;
 }
 static int should_probe(char *bssid) {
 	int x = list_insert(bssid);


### PR DESCRIPTION
When the list was full then clean the list of bssid's cached.